### PR TITLE
Optimize inst dispatch: mark switch default unreachable

### DIFF
--- a/source/Hardware/AvidaVM.hpp
+++ b/source/Hardware/AvidaVM.hpp
@@ -480,7 +480,15 @@ public:
     case 36: Inst_JumpHead(); break;
     case 37: Inst_OffsetHead(); break;
     default:
+      #ifdef NDEBUG // optimization: allow compiler to forgo bounds checking
+      #if defined(_MSC_VER) && !defined(__clang__) // MSVC
+      __assume(false);
+      #else // GCC, Clang
+      __builtin_unreachable();
+      #endif
+      #else // #ifdef NDEBUG
       emp::notify::Error("Instruction ", id, " out of range.");
+      #endif // #ifdef NDEBUG
     }
   }
 


### PR DESCRIPTION
A small optimiation I've noticed have a detectable effect in other bytecode projects!

In C++23, this will be accomplishable more nicely via `std::unreachable();`

As a sidenote, another possible optimization for bytecode dispatch I just recently learned about (but haven't tried myself) is [using a tail call design](https://blog.reverberate.org/2021/04/21/musttail-efficient-interpreters.html), which is being [used in Python3.14](https://docs.python.org/3.14/whatsnew/3.14.html#a-new-type-of-interpreter) for something like a 10% speedup. My understanding is that a current blocking factor on rolling this type of thing out is compiler support for tail-call enforcement via a `musttail` attribute, which is only *just* starting to arrive in the very newest compiler versions.